### PR TITLE
Handle back link on confirm dept

### DIFF
--- a/app/templates/views/auth/confirm_dept.html
+++ b/app/templates/views/auth/confirm_dept.html
@@ -2,7 +2,7 @@
 
 {% block main_content %}
 
-  <a href="/" class="link-back">Back</a>
+  <a href="{{ url_for('main.request_email_address', email_address=session["email_address"]) }}" class="link-back">Back</a>
 
 <div id="confirm-dept">
   <h1 class="heading-large text">Confirm the department that you work for</h1>

--- a/app/templates/views/auth/confirm_email.html
+++ b/app/templates/views/auth/confirm_email.html
@@ -22,7 +22,7 @@
             <span class="error-message">{{error}}</span>
             {% endfor %}
           </label>
-          {{form.email_address(class_="form-control")}}
+          {{form.email_address(class_="form-control", value=request.args['email_address'])}}
         </div>
 
         <label class="block-label selection-button-radio" for="{{subfields[1].id}}">


### PR DESCRIPTION
clicking on back link goes to gateway root on confirm department.

This code change will enable the back link to return to the confirm email page 