### PR TITLE
Fallback if email claim not in userinfo

### DIFF
--- a/app/oidc_client/decorators.py
+++ b/app/oidc_client/decorators.py
@@ -49,9 +49,14 @@ def _authentication_request():
             'redirect_uri': client.registration_response['redirect_uris'][0],
             'state': session['state'],
             'nonce': session['nonce'],
-            'kc_idp_hint': session.get('idp_hint', request.args.get('idp_hint')),
+            'kc_idp_hint': session.get(
+                'idp_hint', request.args.get('idp_hint')),
             'login_hint': session.get('email_address'),
             'claims': {
+                'id_token': {
+                    'email': None,
+                    'name': None
+                },
                 'userinfo': {
                     'email': {'essential': True},
                     'name': {'essential': True}

--- a/app/oidc_client/views.py
+++ b/app/oidc_client/views.py
@@ -79,4 +79,20 @@ def _get_userinfo(id_token, state):
         raise ValueError(
             "The userinfo 'sub' does not match the id token 'sub'")
 
+    if 'email' not in userinfo:
+        current_app.logger.warn('IDP did not supply email claim in userinfo')
+
+        if 'email' in id_token:
+            userinfo['email'] = id_token['email']
+
+        else:
+            current_app.logger.warn(
+                'IDP did not supply email claim in id token')
+
+            if 'email_address' in session:
+                userinfo['email'] = session['email_address']
+
+            else:
+                current_app.logger.warn('User email address unknown')
+
     return userinfo

--- a/tests/test_oidc_client.py
+++ b/tests/test_oidc_client.py
@@ -27,6 +27,10 @@ class TestOIDCClient(object):
             'kc_idp_hint': 'mock_idp_hint',
             'login_hint': 'mock_email_address',
             'claims': {
+                'id_token': {
+                    'email': None,
+                    'name': None
+                },
                 'userinfo': {
                     'email': {'essential': True},
                     'name': {'essential': True}


### PR DESCRIPTION
1. Get email from userinfo
2. If missing, get email from id token
3. If missing, get email from session (user entered email)

* Log each attempt and failure