### PR TITLE
Trigger Sue My Brother build on successful deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,12 +94,11 @@ def runTests(path) {
 
 
 def deployToPaaS(app_name) {
-    def paasUser ='f8b4788a-0383-4c2a-ba4f-64415628debb'
 
     withEnv(["CF_APPNAME=${app_name}"]) {
         withCredentials([
             usernamePassword(
-                credentialsId: paasUser,
+                credentialsId: 'paas-deploy',
                 usernameVariable: 'CF_USER',
                 passwordVariable: 'CF_PASSWORD'),
             file(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,14 @@ node {
                 def url = "https://${app_name}.cloudapps.digital"
                 slackSend color: success, message: "Deployed ${BRANCH_NAME} branch of Gateway to ${url}"
             }
+
+            build(
+                job: 'sue_my_brother/master',
+                parameters: [
+                    string(name: 'OIDC_CLIENT_ISSUER', value: url),
+                    string(name: 'GATEWAY_BRANCH', value: branch)
+                ]
+            )
         }
 
     }


### PR DESCRIPTION
## What

* Add Jenkins pipeline step to build Sue My Brother with parameters
    * `OIDC_CLIENT_ISSUER` set to URL for current Gateway deployment, so that SMB uses this version of the Gateway for authentication
    * `GATEWAY_BRANCH` set to the current Gateway branch, so that an instance of SMB is built to connect to this version of the Gateway, and no other existing SMB instances are disturbed
* Use new named credential for PaaS deployment, to make Jenkinsfile more self-documenting

## How to review

1. Trigger Gateway Jenkins pipeline
2. See that during the Deploy stage, the Sue My Brother Jenkins pipeline is triggered to build the master branch
3. See that Sue My Brother is deployed to PaaS at `https://sue-my-brother-g-{gateway-branch}.cloudapps.digital`
