### PR TITLE
Show an error message if no email address is provided

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -42,13 +42,16 @@ class RequiredIf(InputRequired):
 
 class EmailForm(FlaskForm):
     email_known = RadioField(choices=yesno)
-    email_address = EmailField('Email', validators=[
-        RequiredIf(
-            'email_known',
-            value=YES,
-            message='You must enter a valid email address'),
-        Email(),
-    ])
+    email_address = EmailField(
+        'Email',
+        validators=[
+            RequiredIf(
+                'email_known',
+                value=YES,
+                message='You must enter a valid email address'),
+            Email(),
+        ]
+    )
 
 
 class IdpConfirmForm(FlaskForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,13 +1,15 @@
 from flask_wtf import FlaskForm
 from wtforms import RadioField
 from wtforms.fields.html5 import EmailField
-from wtforms.validators import Email, Optional, Required
+from wtforms.validators import Email, InputRequired, Optional, Required
 
-yesno = [('yes', 'Yes'), ('no', 'No')]
+YES = 'yes'
+NO = 'no'
+yesno = [(YES, 'Yes'), (NO, 'No')]
 
 
 class DeptConfirmForm(FlaskForm):
-    confirm = RadioField(choices=yesno, default='yes')
+    confirm = RadioField(choices=yesno, default=YES)
 
 
 class DeptSelectForm(FlaskForm):
@@ -19,10 +21,34 @@ class ChangeEmailForm(FlaskForm):
         Required(), Email()])
 
 
+class RequiredIf(InputRequired):
+
+    def __init__(self, field_name, value, *args, **kwargs):
+        self.requiring_field_name = field_name
+        self.requiring_value = value
+        super(RequiredIf, self).__init__(*args, **kwargs)
+
+    def __call__(self, form, field):
+        requiring_field = form._fields.get(self.requiring_field_name)
+
+        if requiring_field:
+
+            if requiring_field.data == self.requiring_value:
+                super(RequiredIf, self).__call__(form, field)
+
+            else:
+                return Optional()(form, field)
+
+
 class EmailForm(FlaskForm):
     email_known = RadioField(choices=yesno)
     email_address = EmailField('Email', validators=[
-        Optional(), Email()])
+        RequiredIf(
+            'email_known',
+            value=YES,
+            message='You must enter a valid email address'),
+        Email(),
+    ])
 
 
 class IdpConfirmForm(FlaskForm):

--- a/tests/functional/test_confirm_email_address.py
+++ b/tests/functional/test_confirm_email_address.py
@@ -3,17 +3,17 @@ from flask import url_for
 
 
 @pytest.mark.usefixtures('live_server')
-class When_on_confirm_email_with_yes_selected_and_valid_email(object):
+class When_on_confirm_email_with_yes_selected(object):
 
     @pytest.fixture(autouse=True)
-    def setup_page(
-            self, browser, email_address, set_email_known, set_email_address):
+    def setup_page(self, browser, set_email_known):
         browser.visit(url_for('main.request_email_address', _external=True))
         set_email_known(True)
-        set_email_address(email_address)
 
-    def it_goes_to_department_confirm_when_continue_clicked(
-            self, browser, email_address, department):
+    def it_goes_to_department_confirm_when_valid_email_submitted(
+            self, browser, email_address, department, set_email_address):
+
+        set_email_address(email_address)
 
         browser.find_by_css('form button').click()
 
@@ -22,12 +22,20 @@ class When_on_confirm_email_with_yes_selected_and_valid_email(object):
             '#confirm-dept>div>div').value == email_address
         assert department in browser.find_by_css('#confirm-dept > h2').value
 
+    def it_shows_an_error_if_no_email_address_submitted(self, browser):
+
+        browser.find_by_css('form button').click()
+
+        assert browser.url == url_for(
+            'main.request_email_address', _external=True)
+        assert browser.find_by_css('label[for=email_address] .error-message')
+
 
 @pytest.mark.usefixtures('live_server')
 class When_on_confirm_email_with_no_selected(object):
 
     @pytest.fixture(autouse=True)
-    def setup_page(self, browser, email_address, set_email_known):
+    def setup_page(self, browser, set_email_known):
         browser.visit(url_for('main.request_email_address', _external=True))
         set_email_known(False)
 


### PR DESCRIPTION
## What

* Added `RequiredIf` form validator, to show an error if the user indicates that they know their email address, but do not provide it. The email address is not required if the user indicates that they do not know it.
* Added test for scenario where user does not supply an email address

## How to review

1. Browse to https://ags-gateway-error-missing-email.cloudapps.digital/confirm-email-address (or https://ags-gateway.cloudapps.digital/confirm-email-address if this PR is merged)
2. Click on "Yes"
3. Click on "Continue" button without entering an email address
4. See error message "You must enter a valid email address" next to the form field
5. Click on "No"
6. Click on "Continue" button
7. Be taken to the "Which department do you work for?" page