### PR TITLE
Add ability for Gateway to remember IDP and tests

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -88,8 +88,11 @@ def match_idp_email(idp, email_address):
     return re.match(idp['email_pattern'], email_address)
 
 
-def dept_from_idp_id(id):
-    return [idp['name'] for idp in idp_profiles if id == idp['id']]
+def dept_from_idp_name(idp_name):
+    idp = [idp['name'] for idp in idp_profiles if idp_name == idp['idp_name']]
+    if idp:
+        return ' or '.join(idp)
+    return None
 
 
 def idp_for_dept(dept):
@@ -136,9 +139,10 @@ def authentication_request():
         session['suggested_idp'] = request.args['suggested_idp']
         return redirect(url_for('.confirm_idp'))
 
-    elif (request.cookies.get('gateway_idp')):
+    elif request.cookies.get('gateway_idp'):
         session['suggested_idp'] = request.cookies.get('gateway_idp')
-        session['department_name'] = dept_from_idp_id(session['suggested_idp'])
+        session['department_name'] = dept_from_idp_name(
+            session['suggested_idp'])
         return redirect(url_for('.confirm_dept'))
 
     return redirect(url_for('.request_email_address'))

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -6,6 +6,7 @@ import re
 
 from flask import (
     jsonify,
+    make_response,
     redirect,
     render_template,
     request,
@@ -87,6 +88,10 @@ def match_idp_email(idp, email_address):
     return re.match(idp['email_pattern'], email_address)
 
 
+def dept_from_idp_id(id):
+    return [idp['name'] for idp in idp_profiles if id == idp['id']]
+
+
 def idp_for_dept(dept):
     idp = session['auth_req'].get('dept_idp', '')
     if ',' in idp:
@@ -130,6 +135,11 @@ def authentication_request():
     elif 'suggested_idp' in request.args:
         session['suggested_idp'] = request.args['suggested_idp']
         return redirect(url_for('.confirm_idp'))
+
+    elif (request.cookies.get('gateway_idp')):
+        session['suggested_idp'] = request.cookies.get('gateway_idp')
+        session['department_name'] = dept_from_idp_id(session['suggested_idp'])
+        return redirect(url_for('.confirm_dept'))
 
     return redirect(url_for('.request_email_address'))
 
@@ -233,7 +243,9 @@ def confirm_dept():
 
 @main.route('/to-idp')
 def to_idp():
-    return render_template('views/auth/to_idp.html')
+    resp = make_response(render_template('views/auth/to_idp.html'))
+    resp.set_cookie('gateway_idp', session['suggested_idp'])
+    return resp
 
 
 @main.route('/to-service')

--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -141,8 +141,8 @@ def authentication_request():
 
     elif request.cookies.get('gateway_idp'):
         session['suggested_idp'] = request.cookies.get('gateway_idp')
-        session['department_name'] = dept_from_idp_name(
-            session['suggested_idp'])
+        department = dept_from_idp_name(session['suggested_idp'])
+        session['department_name'] = department
         return redirect(url_for('.confirm_dept'))
 
     return redirect(url_for('.request_email_address'))

--- a/app/templates/views/auth/confirm_dept.html
+++ b/app/templates/views/auth/confirm_dept.html
@@ -7,11 +7,13 @@
 <div id="confirm-dept">
   <h1 class="heading-large text">Confirm the department that you work for</h1>
 
+  {% if session["email_address"] %}
   <div class="text email-callout">
     <p>Email address you provided</p>
     <div class="email-given">{{ session["email_address"] }}</div>
     <p><a id="change_email" href="{{ url_for('main.change_email_address', email_address=session["email_address"]) }}">Change email</a></p>
   </div>
+  {% endif %}
 
   <h2 class="heading-medium">Do you work for the {{ session["department_name"] }}?</h2>
 

--- a/tests/integration/test_user_flows.py
+++ b/tests/integration/test_user_flows.py
@@ -1,0 +1,38 @@
+from bs4 import BeautifulSoup
+from flask import url_for
+import pytest
+
+
+def req(url, method, **kwargs):
+    r = method(url, **kwargs)
+    r.soup = BeautifulSoup(r.get_data(as_text=True), 'html.parser')
+    return r
+
+
+cookie = {'name': 'gateway_idp', 'value': 'gds-google'}
+department = "Government Digital Service"
+
+
+class WhenOnToIDPInterstitial(object):
+
+    @pytest.mark.xfail
+    def it_sets_Gateway_IDP_cookie_to_suggested_IDP_session(self):
+        assert False
+
+
+class WhenNavigatingToAuthPathWithGatewayIDPCookieSet(object):
+
+    @pytest.fixture(autouse=True)
+    def setup_page(self, client):
+        client.set_cookie('localhost', cookie.get('name'), cookie.get('value'))
+        self.response = req(url_for('main.authentication_request'),
+                            client.get, follow_redirects=True)
+
+    def it_redirects_to_department_confirmation_with_department_set(
+            self, client):
+
+        assert department in self.response.soup.select_one("form legend").text
+
+    def it_does_not_show_email_box(self):
+
+        assert self.response.soup.select_one(".email-given") is None

--- a/tests/integration/test_user_flows.py
+++ b/tests/integration/test_user_flows.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from flask import url_for
+from flask import request as req, url_for
 import pytest
 
 
@@ -8,8 +8,8 @@ cookie_value = 'gds-google'
 department = "Government Digital Service"
 
 
-def request(url, method, **kwargs):
-    r = method(url, **kwargs)
+def request(url, method):
+    r = method(url, follow_redirects=True)
     r.soup = BeautifulSoup(r.get_data(as_text=True), 'html.parser')
     return r
 
@@ -20,24 +20,25 @@ class WhenOnToIDPInterstitialWithSuggestedIDPSessionSet(object):
     def setup_page(self, client):
         with client.session_transaction() as session:
             session['suggested_idp'] = cookie_value
-        self.response = request(url_for('main.to_idp'),
-                                client.get, follow_redirects=True)
+        self.response = request(url_for('main.to_idp'), client.get)
 
     def it_stores_suggested_IDP_in_Gateway_IDP_cookie(self):
         cookie = self.response.headers['Set-Cookie']
         assert "{}={};".format(cookie_name, cookie_value) in cookie
 
 
-class WhenNavigatingToAuthPathWithGatewayIDPCookieSet(object):
+class WhenNavigatingToGatewayWithGatewayIDPCookieSet(object):
 
     @pytest.fixture(autouse=True)
     def setup_page(self, client):
         client.set_cookie('localhost', cookie_name, cookie_value)
-        self.response = request(url_for('main.authentication_request'),
-                                client.get, follow_redirects=True)
+        self.response = request(
+            url_for('main.authentication_request'), client.get)
 
     def it_redirects_to_department_confirmation_with_department_set(self):
+        assert url_for('main.confirm_dept') in req.url
         assert department in self.response.soup.select_one("form legend").text
 
     def it_redirects_to_dept_confirm_and_does_not_show_email_given_box(self):
+        assert url_for('main.confirm_dept') in req.url
         assert self.response.soup.select_one(".email-given") is None

--- a/tests/unit/test_auth_functions.py
+++ b/tests/unit/test_auth_functions.py
@@ -1,0 +1,36 @@
+from mock import patch
+
+from app.main.views.auth import dept_from_idp_name
+
+idp_name = 'gds-google'
+department = 'Government Digital Service'
+idp_name_alt = 'co-digital'
+
+idp_profiles = [
+    {
+        'idp_name': 'gds-google',
+        'name': 'Government Digital Service',
+    },
+    {
+        'idp_name': 'co-digital',
+        'name': 'Cabinet Office',
+    },
+    {
+        'idp_name': 'co-digital',
+        'name': 'Crown Commercial Service',
+    },
+]
+
+
+class WhenTestingDeptFromIDPName(object):
+
+    @patch('app.main.views.auth.idp_profiles', idp_profiles)
+    def it_returns_idp_with_valid_idp_name(self):
+        assert dept_from_idp_name(idp_name) == department
+
+    def it_returns_None_with_unknown_idp_name(self):
+        assert dept_from_idp_name('unknown') is None
+
+    @patch('app.main.views.auth.idp_profiles', idp_profiles)
+    def it_returns_OR_seperated_list_for_multiple_departments(self):
+        assert ' or ' in dept_from_idp_name(idp_name_alt)


### PR DESCRIPTION
## What

Added integration and unit tests, and code to handle cookies so that the user has a more seamless journey when revisiting the Gateway on their machine

## How to review

execute run-tests

downloaded on a local machine - 
- navigate to https://localhost:5000/auth 
- enter a valid email supported by Gateway, e.g. xxx@digital.cabinet-office.gov.uk
- click Continue to confirm the department
- log in through the broker, there will be an auth_request error upon return
- change url to https://localhost:5000/auth 
- you should be redirected to the confirm the department page with the remembered department
