### PR TITLE
stop proposition heading being a link

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -43,7 +43,7 @@ information regarding the template.
 <div class='header-proposition'>
   <div class='content'>
     <nav id='proposition-menu'>
-      <a href='/' id='proposition-name'>Choose how to log in</a>
+      <span id='proposition-name'>Choose how to log in</span>
     </nav>
   </div>
 </div>


### PR DESCRIPTION
## What

I've stopped the proposition heading being a link to an incomplete product page because in testing some users accidentally clicked on it and they were then lost before completing the authentication steps.
