### PR TITLE
Add Home Office Digital email pattern

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -57,6 +57,14 @@ idp_profiles = [
         'email_pattern': '^[^@]+@crowncommercial\.gov\.uk$',
         'hint': 'CCS staff, @crowncommercial.gov.uk accounts'
     },
+    {
+        'id': 'HOD',
+        'idp_name': 'HOD',
+        'name': 'Home Office Digital',
+        'email_pattern': '^[^@]+@digital\.homeoffice\.gov\.uk$',
+        'hint': (
+            'Home Office Digital staff, @digital.homeoffice.gov.uk accounts.')
+    },
     # csc.gov.uk
     # csep.gov.uk
     # cslearning.gov.uk

--- a/tests/unit/test_auth_functions.py
+++ b/tests/unit/test_auth_functions.py
@@ -1,6 +1,6 @@
 from mock import patch
 
-from app.main.views.auth import dept_from_idp_name
+from app.main.views.auth import dept_from_idp_name, idp_from_email_address
 
 idp_name = 'gds-google'
 department = 'Government Digital Service'
@@ -34,3 +34,12 @@ class WhenTestingDeptFromIDPName(object):
     @patch('app.main.views.auth.idp_profiles', idp_profiles)
     def it_returns_OR_seperated_list_for_multiple_departments(self):
         assert ' or ' in dept_from_idp_name(idp_name_alt)
+
+
+class WhenTestingIDPFromEmailAddress(object):
+
+    def it_returns_HOD_IDP_for_Home_Office_Digital_email_address(self):
+        email_address = 'some.one@digital.homeoffice.gov.uk'
+        idp = idp_from_email_address(email_address)
+
+        assert idp[0]['idp_name'] == 'HOD'


### PR DESCRIPTION
## What

Add Home Office Digital email pattern so that the confirm department page will pick up the email and department name

## How to review

execute run-tests
