### PR TITLE
Ensure deploy step is executed on master node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,18 @@ node {
             parallel (
 
                 "Deploy to PaaS": {
-                    deployToPaaS(appName)
+
+                    stash(
+                        name: "app",
+                        includes: ".cfignore,Procfile,app/**,deploy-to-paas,lib/**,*.yml,*.txt,*.pem"
+                    )
+
+                    node('master') {
+
+                        unstash "app"
+
+                        deployToPaaS(appName)
+                    }
 
                     if (BRANCH_NAME == 'master') {
                         slackSend color: success, message: "Deployed ${BRANCH_NAME} branch of Gateway to ${url}"


### PR DESCRIPTION
## What
* Updated Jenkinsfile to use `node("master")` to run deploy to PaaS step, as PaaS only whitelists the master Jenkins IP and not the slave nodes. This fixes builds on the slave nodes.

## How to review

1. See a build in Jenkins that uses a slave node and fails with a `RequestError`, eg: http://jenkins.civilservice.digital:8080/blue/organizations/jenkins/gateway/detail/heading-link-fix/1/pipeline/66
2. See this build specify the master node for execution of the Deploy step